### PR TITLE
Fix PlaceOrders

### DIFF
--- a/Processor/PlaceOrders.pm
+++ b/Processor/PlaceOrders.pm
@@ -25,7 +25,8 @@ sub run {
     my $dbh   = C4::Context->dbh;
     my $query = "
         SELECT * FROM illrequests
-        WHERE status='READY' ORDER BY illrequest_id ASC
+        WHERE status='READY' AND orderid IS NULL
+        ORDER BY illrequest_id ASC
         LIMIT 15;
     ";
     my $sth = $dbh->prepare($query);

--- a/intra-includes/illview.inc
+++ b/intra-includes/illview.inc
@@ -21,6 +21,10 @@
 <script>
     document.addEventListener('DOMContentLoaded', function(){
 
+        // Hide "Mark request READY" button if an Order ID exists
+        if( $('li.orderid').text().indexOf('N/A') == -1 ){
+            $('#ill-toolbar-btn-ready').hide();
+        }
         // The Reprints Desk API doesn't have any provision for request cancellation
         // so we need to hide the cancel button
         $('#ill-toolbar-btn-reqrev').hide();


### PR DESCRIPTION
This is doing 2 things:
- Hiding the 'Mark request READY' button if a request already has an orderID. This is to prevent staff members from placing it back to 'READY' if it has already been placed with ReprintsDesk. We keep the 'Mark request READY' button otherwise because it may 'ERROR' without a orderID and staff can still mark it 'READY' if that is the case.

- PlaceOrders now only picks up 'READY' requests with orderID = NULL This is a fail-safe redundancy to the above, it should never happen that a 'READY' request has a orderID, but we're still making sure that this cronjob is idempotent and won't attempt to re-place an order with ReprintsDesk that already has been placed in the past