### PR TITLE
Handle API param change

### DIFF
--- a/Base.pm
+++ b/Base.pm
@@ -556,7 +556,8 @@ sub create_submission {
     $request->borrowernumber( $patron->borrowernumber );
     $request->branchcode( $params->{other}->{branchcode} );
     $request->status('NEW');
-    $request->batch_id( $params->{other}->{batch_id} );
+    $request->batch_id(
+        $params->{other}->{ill_batch_id} ? $params->{other}->{ill_batch_id} : $params->{other}->{batch_id} );
     $request->backend( $self->name );
     $request->placed( DateTime->now );
     $request->updated( DateTime->now );


### PR DESCRIPTION
QA work on 30719 changed the API param being sent from batch_id to ill_batch_id. Here, check for either because live systems with 30719 backported may still be using the old batch_id